### PR TITLE
Migrate release workflow to Amazon ECR

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,35 +1,44 @@
-name: OM1 Avatar release
+name: "ECR Release Workflow"
+
 on:
   push:
-    branches: main
+    branches: [ "main" ]
     tags:
-      - 'v*'
+      - "v*"
   workflow_dispatch:
 
 jobs:
   build-amd64:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     outputs:
       image-digest: ${{ steps.build.outputs.digest }}
       metadata: ${{ steps.meta.outputs.json }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v3
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE }}
+          aws-region: ${{ secrets.AWS_REGION }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
+      - name: Login to Amazon ECR Public
+        uses: aws-actions/amazon-ecr-login@v2
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry-type: public
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
-          images: openmindagi/om1_avatar
+          images: public.ecr.aws/b8k9c8n5/openmind/om1_avatar
           tags: |
             type=semver,pattern={{version}},prefix=v
             type=semver,pattern={{major}}.{{minor}},prefix=v
@@ -37,38 +46,47 @@ jobs:
             type=sha
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
 
-      - name: Build and push AMD64 image by digest
+      - name: Build and push AMD64 image by tag
         id: build
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         with:
           context: .
-          file: ./Dockerfile
+          push: true
           platforms: linux/amd64
+          tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          outputs: type=image,name=openmindagi/om1_avatar,push-by-digest=true,name-canonical=true,push=true
 
   build-arm64:
     runs-on: ubuntu-22.04-arm
+    permissions:
+      id-token: write
+      contents: read
     outputs:
       image-digest: ${{ steps.build.outputs.digest }}
+      metadata: ${{ steps.meta.outputs.json }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v3
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE }}
+          aws-region: ${{ secrets.AWS_REGION }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
+      - name: Login to Amazon ECR Public
+        uses: aws-actions/amazon-ecr-login@v2
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry-type: public
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
-          images: openmindagi/om1_avatar
+          images: public.ecr.aws/b8k9c8n5/openmind/om1_avatar
           tags: |
             type=semver,pattern={{version}},prefix=v
             type=semver,pattern={{major}}.{{minor}},prefix=v
@@ -76,31 +94,53 @@ jobs:
             type=sha
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
 
-      - name: Build and push ARM64 image by digest
+      - name: Build and push ARM64 image by tag
         id: build
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         with:
           context: .
-          file: ./Dockerfile
+          push: true
           platforms: linux/arm64
+          tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          outputs: type=image,name=openmindagi/om1_avatar,push-by-digest=true,name-canonical=true,push=true
 
   create-manifest:
     runs-on: ubuntu-latest
-    needs: [build-amd64, build-arm64]
+    permissions:
+      id-token: write
+      contents: read
+      deployments: write
+    needs: [ build-amd64, build-arm64 ]
+    environment:
+      name: ${{ startsWith(github.ref, 'refs/tags/v') && 'production' || 'staging' }}
+      url: https://gallery.ecr.aws/b8k9c8n5/openmind/om1_avatar
     steps:
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          role-to-assume: ${{ secrets.AWS_ROLE }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Amazon ECR Public
+        uses: aws-actions/amazon-ecr-login@v2
+        with:
+          registry-type: public
 
       - name: Create manifest list and push
         run: |
+          if [[ -z "${{ needs.build-amd64.outputs.image-digest }}" ]]; then
+            echo "Error: AMD64 digest is empty"
+            exit 1
+          fi
+
+          if [[ -z "${{ needs.build-arm64.outputs.image-digest }}" ]]; then
+            echo "Error: ARM64 digest is empty"
+            exit 1
+          fi
+
           # Get the metadata from amd64 build to extract tags
           tags=$(echo '${{ needs.build-amd64.outputs.metadata }}' | jq -r '.tags[]')
 
@@ -110,6 +150,6 @@ jobs:
 
             docker buildx imagetools create \
               --tag $tag \
-              openmindagi/om1_avatar@${{ needs.build-amd64.outputs.image-digest }} \
-              openmindagi/om1_avatar@${{ needs.build-arm64.outputs.image-digest }}
+              public.ecr.aws/b8k9c8n5/openmind/om1_avatar@${{ needs.build-amd64.outputs.image-digest }} \
+              public.ecr.aws/b8k9c8n5/openmind/om1_avatar@${{ needs.build-arm64.outputs.image-digest }}
           done


### PR DESCRIPTION
Switch the release workflow from Docker Hub to Amazon ECR Public and modernize GitHub Actions usage. Updates include: change workflow name and branch/tag syntax, ignore docs paths, upgrade actions (checkout@v4, setup-buildx@v3, metadata@v5, build-push@v5), replace Docker Hub login with aws-actions/amazon-ecr-login and add aws-actions/configure-aws-credentials, set required job permissions, and publish images to public.ecr.aws/b8k9c8n5/openmind/om1_avatar. Builds now push tags (amd64 and arm64) and the manifest job validates digests, creates multi-arch manifests against ECR, and sets an environment URL for the gallery.