### PR TITLE
remove the typing animation

### DIFF
--- a/src/components/Subtitles.tsx
+++ b/src/components/Subtitles.tsx
@@ -1,45 +1,9 @@
-import { useState, useEffect } from 'react';
-
 interface SubtitlesProps {
   text: string;
 }
 
 export function Subtitles({ text }: SubtitlesProps) {
-  const [displayedText, setDisplayedText] = useState('');
-
-  useEffect(() => {
-    if (!text) {
-      setDisplayedText('');
-      return;
-    }
-
-    setDisplayedText('');
-    let currentIndex = 0;
-    let timeoutId: NodeJS.Timeout;
-
-    const typeNextChar = () => {
-      if (currentIndex < text.length) {
-        setDisplayedText(text.slice(0, currentIndex + 1));
-        currentIndex++;
-        
-        const currentChar = text[currentIndex - 1];
-        const isPunctuation = /[.,!?;:]/.test(currentChar);
-
-        let delay = 50;
-        if (isPunctuation) delay = 150;
-
-        timeoutId = setTimeout(typeNextChar, delay);
-      }
-    };
-    
-    typeNextChar();
-
-    return () => {
-      if (timeoutId) clearTimeout(timeoutId);
-    };
-  }, [text]);
-
-  if (!text && !displayedText) return null;
+  if (!text) return null;
 
   return (
     <div className="fixed bottom-8 left-0 right-0 flex justify-center z-40 pointer-events-none px-4">
@@ -54,7 +18,7 @@ export function Subtitles({ text }: SubtitlesProps) {
         }}
       >
         <p className="text-white/95 text-center text-2xl md:text-3xl font-medium leading-relaxed tracking-wide">
-          {displayedText}
+          {text}
         </p>
       </div>
     </div>


### PR DESCRIPTION
This pull request simplifies the `Subtitles` component by removing the typewriter animation effect and directly displaying the full subtitle text. The code is now easier to maintain and more efficient.

**Component simplification:**

* Removed the `useState` and `useEffect` logic that animated the subtitle text letter-by-letter, including punctuation-based delays, from the `Subtitles` component. Now, the component simply renders the provided `text` prop if it exists.
* Updated the rendered content to display the full `text` prop immediately, instead of the previously animated `displayedText`.